### PR TITLE
Correct cookie expiry format string

### DIFF
--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -189,7 +189,7 @@ parseSetCookie a = SetCookie
                   in (k, v) : parsePairs bs'
 
 expiresFormat :: String
-expiresFormat = "%a, %d-%b-%Y %X GMT"
+expiresFormat = "%a, %d-%b-%y %X GMT"
 
 -- | Format a 'UTCTime' for a cookie.
 formatCookieExpires :: UTCTime -> S.ByteString


### PR DESCRIPTION
"Mon, 29-Jul-24 04:52:08 GMT" is parsed as Just 0024-07-29 04:52:08 UTC
instead of 2024.

This small change seems to fix the problem.

From Date.Time.Format haddock (not very clear)
%Y
year, no padding. Note %0y and %_y pad to four chars
%y
year of century, 0-padded to two chars, 00 - 99
...
In the absence of %C or %Y, century is 1969 - 2068.
