### PR TITLE
Fix parseSetCookie #7

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -65,12 +65,16 @@ instance Arbitrary SetCookie where
         expires <- fmap (parseCookieExpires . formatCookieExpires)
                     (UTCTime <$> fmap toEnum arbitrary <*> return 0)
         domain <- fmap (fmap fromUnChars) arbitrary
+        httponly <- arbitrary
+        secure <- arbitrary
         return def
             { setCookieName = name
             , setCookieValue = value
             , setCookiePath = path
             , setCookieExpires = expires
             , setCookieDomain = domain
+            , setCookieHttpOnly = httponly
+            , setCookieSecure = secure
             }
 
 caseParseCookies :: Assertion


### PR DESCRIPTION
A simple fix for issue #7. Split the cookie string by semicolons first and then parse pairs by splitting on equals sign.
