### PR TITLE
Needs time >= 1.4

### DIFF
--- a/cookie.cabal
+++ b/cookie.cabal
@@ -16,7 +16,7 @@ library
                    , bytestring                >= 0.9.1.4
                    , blaze-builder             >= 0.2.1
                    , old-locale                >= 1
-                   , time                      >= 1.1.4
+                   , time                      >= 1.4
                    , text                      >= 0.7
                    , data-default-class
                    , deepseq


### PR DESCRIPTION
```
Web/Cookie.hs:120:9:
    No instance for (NFData DiffTime)
      arising from a use of `rnf'
    Possible fix: add an instance declaration for (NFData DiffTime)
    In the first argument of `seq', namely `rnf e'
    In the second argument of `seq', namely
      `rnf e `seq` rnfMBS f `seq` rnf g `seq` rnf h'
    In the second argument of `seq', namely
      `rnf d `seq` rnf e `seq` rnfMBS f `seq` rnf g `seq` rnf h'
```