### PR TITLE
Adds `setCookieSameSite` security option.

### DIFF
--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -13,7 +13,9 @@ module Web.Cookie
     , setCookieHttpOnly
     , setCookieSecure
     , setCookieSameSite
-    , SameSiteOption(..)
+    , SameSiteOption
+    , sameSiteLax
+    , sameSiteStrict
       -- ** Functions
     , parseSetCookie
     , renderSetCookie
@@ -133,6 +135,12 @@ data SameSiteOption = Lax | Strict deriving (Show, Eq)
 
 instance NFData SameSiteOption where
   rnf _ = ()
+
+sameSiteLax :: SameSiteOption
+sameSiteLax = Lax
+
+sameSiteStrict :: SameSiteOption
+sameSiteStrict = Strict
 
 instance NFData SetCookie where
     rnf (SetCookie a b c d e f g h i) =

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -199,9 +199,9 @@ renderSetCookie sc = mconcat
         then copyByteString "; Secure"
         else mempty
     , case setCookieSameSite sc of
-      Nothing -> mempty
-      Just Lax -> copyByteString "; SameSite=Lax"
-      Just Strict -> copyByteString "; SameSite=Strict"
+        Nothing -> mempty
+        Just Lax -> copyByteString "; SameSite=Lax"
+        Just Strict -> copyByteString "; SameSite=Strict"
     ]
 
 parseSetCookie :: S.ByteString -> SetCookie
@@ -217,9 +217,9 @@ parseSetCookie a = SetCookie
     , setCookieHttpOnly = isJust $ lookup "httponly" flags
     , setCookieSecure = isJust $ lookup "secure" flags
     , setCookieSameSite = case lookup "samesite" flags of
-      Just "Lax" -> Just Lax
-      Just "Strict" -> Just Strict
-      _ -> Nothing
+        Just "Lax" -> Just Lax
+        Just "Strict" -> Just Strict
+        _ -> Nothing
     }
   where
     pairs = map (parsePair . dropSpace) $ S.split 59 a ++ [S8.empty] -- 59 = semicolon

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -131,6 +131,9 @@ data SetCookie = SetCookie
 -- | Data type representing the options for a SameSite cookie
 data SameSiteOption = Lax | Strict deriving (Show, Eq)
 
+instance NFData SameSiteOption where
+  rnf _ = ()
+
 instance NFData SetCookie where
     rnf (SetCookie a b c d e f g h i) =
         a `seq`
@@ -141,7 +144,7 @@ instance NFData SetCookie where
         rnfMBS f `seq`
         rnf g `seq`
         rnf h `seq`
-        rnfMBS i
+        rnf i
       where
         -- For backwards compatibility
         rnfMBS Nothing = ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -52,6 +52,9 @@ instance Show Char' where
     showList = (++) . show . concatMap show
 instance Arbitrary Char' where
     arbitrary = fmap (Char' . toEnum) $ choose (62, 125)
+newtype SameSiteOption' = SameSiteOption' { unSameSiteOption' :: SameSiteOption }
+instance Arbitrary SameSiteOption' where
+  arbitrary = fmap SameSiteOption' (elements [Lax, Strict])
 
 propParseRenderSetCookie :: SetCookie -> Bool
 propParseRenderSetCookie sc =
@@ -67,6 +70,7 @@ instance Arbitrary SetCookie where
         domain <- fmap (fmap fromUnChars) arbitrary
         httponly <- arbitrary
         secure <- arbitrary
+        sameSite <- fmap (fmap unSameSiteOption') arbitrary
         return def
             { setCookieName = name
             , setCookieValue = value
@@ -75,6 +79,7 @@ instance Arbitrary SetCookie where
             , setCookieDomain = domain
             , setCookieHttpOnly = httponly
             , setCookieSecure = secure
+            , setCookieSameSite = sameSite
             }
 
 caseParseCookies :: Assertion

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -54,7 +54,7 @@ instance Arbitrary Char' where
     arbitrary = fmap (Char' . toEnum) $ choose (62, 125)
 newtype SameSiteOption' = SameSiteOption' { unSameSiteOption' :: SameSiteOption }
 instance Arbitrary SameSiteOption' where
-  arbitrary = fmap SameSiteOption' (elements [Lax, Strict])
+  arbitrary = fmap SameSiteOption' (elements [sameSiteLax, sameSiteStrict])
 
 propParseRenderSetCookie :: SetCookie -> Bool
 propParseRenderSetCookie sc =


### PR DESCRIPTION
SameSite is an interesting cookie option that asserts that a cookie
should not be included in cross-origin requests. This commit adds a sum
type `SameSiteOption` and a function `setCookieSameSite` for interacting
with this option.

Here is the draft: https://tools.ietf.org/html/draft-west-first-party-cookies-07