### PR TITLE
add defaultSetCookie

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Added `defaultSetCookie` [#16](https://github.com/snoyberg/cookie/pull/16)
+
 ## 0.4.2.1
 
 * Clarified MIT license

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -19,6 +19,7 @@ module Web.Cookie
       -- ** Functions
     , parseSetCookie
     , renderSetCookie
+    , defaultSetCookie
     , def
       -- * Client to server
     , Cookies
@@ -106,12 +107,12 @@ renderCookie (k, v) = fromByteString k `mappend` fromChar '='
 --
 -- ==== Creating a SetCookie
 --
--- 'SetCookie' does not export a constructor; instead, use the 'Default' instance to create one and override values (see <http://www.yesodweb.com/book/settings-types> for details):
+-- 'SetCookie' does not export a constructor; instead, use 'defaultSetCookie' and override values (see <http://www.yesodweb.com/book/settings-types> for details):
 --
 -- @
 -- import Web.Cookie
 -- :set -XOverloadedStrings
--- let cookie = 'def' { 'setCookieName' = "cookieName", 'setCookieValue' = "cookieValue" }
+-- let cookie = 'defaultSetCookie' { 'setCookieName' = "cookieName", 'setCookieValue' = "cookieValue" }
 -- @
 --
 -- ==== Cookie Configuration
@@ -158,18 +159,25 @@ instance NFData SetCookie where
         rnfMBS Nothing = ()
         rnfMBS (Just bs) = bs `seq` ()
 
+-- | @'def' = 'defaultSetCookie'@
 instance Default SetCookie where
-    def = SetCookie
-        { setCookieName     = "name"
-        , setCookieValue    = "value"
-        , setCookiePath     = Nothing
-        , setCookieExpires  = Nothing
-        , setCookieMaxAge   = Nothing
-        , setCookieDomain   = Nothing
-        , setCookieHttpOnly = False
-        , setCookieSecure   = False
-        , setCookieSameSite = Nothing
-        }
+    def = defaultSetCookie
+
+-- | A minimal 'SetCookie'. All fields are 'Nothing' or 'False' except @'setCookieName' = "name"@ and @'setCookieValue' = "value"@. You need this to construct a 'SetCookie', because it does not export a constructor. Equivalently, you may use 'def'.
+--
+-- @since 0.4.2.2
+defaultSetCookie :: SetCookie
+defaultSetCookie = SetCookie
+    { setCookieName     = "name"
+    , setCookieValue    = "value"
+    , setCookiePath     = Nothing
+    , setCookieExpires  = Nothing
+    , setCookieMaxAge   = Nothing
+    , setCookieDomain   = Nothing
+    , setCookieHttpOnly = False
+    , setCookieSecure   = False
+    , setCookieSameSite = Nothing
+    }
 
 renderSetCookie :: SetCookie -> Builder
 renderSetCookie sc = mconcat

--- a/cookie.cabal
+++ b/cookie.cabal
@@ -1,5 +1,5 @@
 name:            cookie
-version:         0.4.2.1
+version:         0.4.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Hello, would you mind accepting this monomorphic alternative to `def` for the base `SetCookie` value? I don't think the `Default` class is really helpful for most use cases here, so it would be nice for the library to provide this value more directly in non-overloaded form.

I also added a bit of documentation explaining what field values `defaultSetCookie` contains.