### PR TITLE
drop support GHC<=7.8; drop dep. blaze-builder

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.4.4
+
+* Dropped support for GHC<=7.8.x
+* Dropped dependency on blaze-builder
+
 ## 0.4.3
 
 * Added `defaultSetCookie` [#16](https://github.com/snoyberg/cookie/pull/16)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 ## 0.4.4
 
-* Dropped support for GHC<=7.8.x
 * Dropped dependency on blaze-builder
+* Made cookie text rendering slightly more efficient
 
 ## 0.4.3
 

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Web.Cookie
     ( -- * Server to client
@@ -38,18 +37,13 @@ module Web.Cookie
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import Data.Char (toLower, isDigit)
-import Blaze.ByteString.Builder (Builder, fromByteString, copyByteString)
-import Blaze.ByteString.Builder.Char8 (fromChar)
+import Data.ByteString.Builder (Builder, byteString, char8)
+import Data.ByteString.Builder.Extra (byteStringCopy)
 import Data.Monoid (mempty, mappend, mconcat)
 import Data.Word (Word8)
 import Data.Ratio (numerator, denominator)
-import Data.Time (UTCTime (UTCTime), toGregorian, fromGregorian, formatTime, parseTimeM)
+import Data.Time (UTCTime (UTCTime), toGregorian, fromGregorian, formatTime, parseTimeM, defaultTimeLocale)
 import Data.Time.Clock (DiffTime, secondsToDiffTime)
-#if MIN_VERSION_time(1, 5, 0)
-import Data.Time (defaultTimeLocale)
-#else
-import System.Locale (defaultTimeLocale)
-#endif
 import Control.Arrow (first, (***))
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8With)
@@ -97,11 +91,11 @@ renderCookies [] = mempty
 renderCookies cs =
     foldr1 go $ map renderCookie cs
   where
-    go x y = x `mappend` fromChar ';' `mappend` y
+    go x y = x `mappend` char8 ';' `mappend` y
 
 renderCookie :: (S.ByteString, S.ByteString) -> Builder
-renderCookie (k, v) = fromByteString k `mappend` fromChar '='
-                                       `mappend` fromByteString v
+renderCookie (k, v) = byteString k `mappend` char8 '='
+                                       `mappend` byteString v
 -- | Data type representing the key-value pair to use for a cookie, as well as configuration options for it.
 --
 -- ==== Creating a SetCookie
@@ -184,35 +178,35 @@ defaultSetCookie = SetCookie
 
 renderSetCookie :: SetCookie -> Builder
 renderSetCookie sc = mconcat
-    [ fromByteString (setCookieName sc)
-    , fromChar '='
-    , fromByteString (setCookieValue sc)
+    [ byteString (setCookieName sc)
+    , char8 '='
+    , byteString (setCookieValue sc)
     , case setCookiePath sc of
         Nothing -> mempty
-        Just path -> copyByteString "; Path="
-                     `mappend` fromByteString path
+        Just path -> byteStringCopy "; Path="
+                     `mappend` byteString path
     , case setCookieExpires sc of
         Nothing -> mempty
-        Just e -> copyByteString "; Expires=" `mappend`
-                  fromByteString (formatCookieExpires e)
+        Just e -> byteStringCopy "; Expires=" `mappend`
+                  byteString (formatCookieExpires e)
     , case setCookieMaxAge sc of
         Nothing -> mempty
-        Just ma -> copyByteString"; Max-Age=" `mappend`
-                   fromByteString (formatCookieMaxAge ma)
+        Just ma -> byteStringCopy"; Max-Age=" `mappend`
+                   byteString (formatCookieMaxAge ma)
     , case setCookieDomain sc of
         Nothing -> mempty
-        Just d -> copyByteString "; Domain=" `mappend`
-                  fromByteString d
+        Just d -> byteStringCopy "; Domain=" `mappend`
+                  byteString d
     , if setCookieHttpOnly sc
-        then copyByteString "; HttpOnly"
+        then byteStringCopy "; HttpOnly"
         else mempty
     , if setCookieSecure sc
-        then copyByteString "; Secure"
+        then byteStringCopy "; Secure"
         else mempty
     , case setCookieSameSite sc of
         Nothing -> mempty
-        Just Lax -> copyByteString "; SameSite=Lax"
-        Just Strict -> copyByteString "; SameSite=Strict"
+        Just Lax -> byteStringCopy "; SameSite=Lax"
+        Just Strict -> byteStringCopy "; SameSite=Strict"
     ]
 
 parseSetCookie :: S.ByteString -> SetCookie

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -62,7 +62,7 @@ parseCookiesText =
     go = decodeUtf8With lenientDecode
 
 renderCookiesText :: CookiesText -> Builder
-renderCookiesText = renderCookies . map (encodeUtf8Builder *** encodeUtf8Builder)
+renderCookiesText = renderCookiesBuilder . map (encodeUtf8Builder *** encodeUtf8Builder)
 
 type Cookies = [(S.ByteString, S.ByteString)]
 
@@ -87,15 +87,18 @@ breakDiscard w s =
 
 type CookieBuilder = (Builder, Builder)
 
-renderCookies :: [CookieBuilder] -> Builder
-renderCookies [] = mempty
-renderCookies cs =
+renderCookiesBuilder :: [CookieBuilder] -> Builder
+renderCookiesBuilder [] = mempty
+renderCookiesBuilder cs =
     foldr1 go $ map renderCookie cs
   where
     go x y = x `mappend` char8 ';' `mappend` y
 
 renderCookie :: CookieBuilder -> Builder
 renderCookie (k, v) = k `mappend` char8 '=' `mappend` v
+
+renderCookies :: Cookies -> Builder
+renderCookies = renderCookiesBuilder . map (byteString *** byteString)
 
 -- | Data type representing the key-value pair to use for a cookie, as well as configuration options for it.
 --

--- a/cookie.cabal
+++ b/cookie.cabal
@@ -17,7 +17,7 @@ library
     build-depends:   base                      >= 4        && < 5
                    , bytestring                >= 0.10.2
                    , time                      >= 1.5
-                   , text                      >= 0.7
+                   , text                      >= 1.1
                    , data-default-class
                    , deepseq
     exposed-modules: Web.Cookie

--- a/cookie.cabal
+++ b/cookie.cabal
@@ -30,13 +30,12 @@ test-suite test
     build-depends: base
                  , HUnit
                  , QuickCheck
-                 , blaze-builder
-                 , bytestring
+                 , bytestring >= 0.10.2
                  , cookie
                  , tasty
                  , tasty-hunit
                  , tasty-quickcheck
-                 , text
+                 , text >= 1.1
                  , time >= 1.5
 
 source-repository head

--- a/cookie.cabal
+++ b/cookie.cabal
@@ -1,5 +1,5 @@
 name:            cookie
-version:         0.4.3
+version:         0.4.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -15,9 +15,7 @@ extra-source-files: README.md ChangeLog.md
 
 library
     build-depends:   base                      >= 4        && < 5
-                   , bytestring                >= 0.9.1.4
-                   , blaze-builder             >= 0.2.1
-                   , old-locale                >= 1
+                   , bytestring                >= 0.10.2
                    , time                      >= 1.5
                    , text                      >= 0.7
                    , data-default-class

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -29,12 +29,9 @@ main = defaultMain $ testGroup "cookie"
 
 propParseRenderCookies :: Cookies' -> Bool
 propParseRenderCookies cs' =
-    parseCookies (builderToBs $ renderCookies cs) == csBS
+    parseCookies (builderToBs $ renderCookies cs) == cs
   where
-    char'sToBuilder :: [Char'] -> Builder
-    char'sToBuilder = mconcat . map (word8 . unChar') 
-    csBS = map (fromUnChars *** fromUnChars) cs'
-    cs = map (char'sToBuilder *** char'sToBuilder) cs'
+    cs = map (fromUnChars *** fromUnChars) cs'
 
 propParseRenderCookiesText :: Cookies' -> Bool
 propParseRenderCookiesText cs' =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,7 +5,7 @@ import Test.QuickCheck
 import Test.HUnit ((@=?), Assertion)
 
 import Web.Cookie
-import Blaze.ByteString.Builder (Builder, toLazyByteString)
+import Data.ByteString.Builder (Builder, word8, toLazyByteString)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
@@ -28,9 +28,12 @@ main = defaultMain $ testGroup "cookie"
 
 propParseRenderCookies :: Cookies' -> Bool
 propParseRenderCookies cs' =
-    parseCookies (builderToBs $ renderCookies cs) == cs
+    parseCookies (builderToBs $ renderCookies cs) == csBS
   where
-    cs = map (fromUnChars *** fromUnChars) cs'
+    char'sToBuilder :: [Char'] -> Builder
+    char'sToBuilder = mconcat . map (word8 . unChar') 
+    csBS = map (fromUnChars *** fromUnChars) cs'
+    cs = map (char'sToBuilder *** char'sToBuilder) cs'
 
 propParseRenderCookiesText :: Cookies' -> Bool
 propParseRenderCookiesText cs' =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
 import Data.Word (Word8)
+import Data.Monoid (mconcat)
 import Control.Arrow ((***))
 import Control.Applicative ((<$>), (<*>))
 import Data.Time (UTCTime (UTCTime), toGregorian)


### PR DESCRIPTION
`blaze-builder` has not managed to merge existing PRs implementing the Semigroup-Monoid-Propasel so far, despite of various issues/notifications. Now with GHC 8.4.1 out, I thought I'd suggest to remove that dependency from `cookie`, a package I desperately need, byte using `bytestring`'s `Builder` type directly.

Also, I dropped support for GHC <= 7.8.x by removing `old-locale`, so the API is CPP-less now.

While I'm at it, I could implement
```
-- FIXME to speed things up, skip encodeUtf8 and use fromText instead
```
which you noted in a comment?

Interested in merging the PR, or is there show-stopper from your point of view?

**Edit:**
I just saw in Travis, it builds just fine with GHC 7.6.3 - please forget about the statement "dropping GHC<=7.8 support". Since the `time` dependency is explicitly stated, all works fine.