### PR TITLE
Resolve redundant import of Data.Monoid

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Resolve redundant import of Data.Monoid [#26](https://github.com/snoyberg/cookie/pull/26)
+
 ## 0.4.5
 
 * Added `SameSite=None`

--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Web.Cookie
     ( -- * Server to client
@@ -40,7 +41,9 @@ import qualified Data.ByteString.Char8 as S8
 import Data.Char (toLower, isDigit)
 import Data.ByteString.Builder (Builder, byteString, char8)
 import Data.ByteString.Builder.Extra (byteStringCopy)
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (mempty, mappend, mconcat)
+#endif
 import Data.Word (Word8)
 import Data.Ratio (numerator, denominator)
 import Data.Time (UTCTime (UTCTime), toGregorian, fromGregorian, formatTime, parseTimeM, defaultTimeLocale)


### PR DESCRIPTION
This resolves a compiler warning about the redundant import with recent
versions of base that include Monoid in Prelude.

If you don't want to add the CPP directive, we can increase the required version of `base` or just leave everything as-is and live with the warnings. Let me know what you think.