### PR TITLE
Remove surrounding double quotes from cookie values when parsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+## 0.5.0
+
+* Remove surrounding double quotes from cookie values when parsing [#31](https://github.com/snoyberg/cookie/pull/31)
+
+  This is a breaking change, as it changes the behavior of `parseCookies` and `parseSetCookie` to no
+  longer include the surrounding double quotes in the cookie value. This is the correct behavior
+  according to the RFC.
+
 ## 0.4.6
 
 * Resolve redundant import of Data.Monoid [#26](https://github.com/snoyberg/cookie/pull/26)

--- a/cookie.cabal
+++ b/cookie.cabal
@@ -1,5 +1,5 @@
 name:            cookie
-version:         0.4.6
+version:         0.5.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,6 +22,8 @@ main = defaultMain $ testGroup "cookie"
     , testProperty "parse/render SetCookie" propParseRenderSetCookie
     , testProperty "parse/render cookies text" propParseRenderCookiesText
     , testCase "parseCookies" caseParseCookies
+    , testCase "parseQuotedCookies" caseParseQuotedCookies
+    , testCase "parseQuotedSetCookie" caseParseQuotedSetCookie
     , twoDigit 24 2024
     , twoDigit 69 2069
     , twoDigit 70 1970
@@ -106,3 +108,17 @@ twoDigit x y =
         , show x
         , " 04:52:08 GMT"
         ]
+
+caseParseQuotedCookies :: Assertion
+caseParseQuotedCookies = do
+    let input = S8.pack "a=\"a1\";b=\"b2\"; c=\"c3\""
+        expected = [("a", "a1"), ("b", "b2"), ("c", "c3")]
+    map (S8.pack *** S8.pack) expected @=? parseCookies input
+
+caseParseQuotedSetCookie :: Assertion
+caseParseQuotedSetCookie = do
+    let input = S8.pack "a=\"a1\""
+        result = parseSetCookie input
+        resultNameAndValue = (setCookieName result, setCookieValue result)
+        expected = (S8.pack "a", S8.pack "a1")
+    expected @=? resultNameAndValue


### PR DESCRIPTION
Resolves #22 

I bumped the major version, but maybe that isn't strictly necessary.