### PR TITLE
Replace Data.List.NonEmpty with Data.Maybe functions

### DIFF
--- a/Web/Cookie.hs
+++ b/Web/Cookie.hs
@@ -55,10 +55,9 @@ import Control.Arrow (first, (***))
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8Builder, decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, fromMaybe, listToMaybe)
 import Data.Default.Class (Default (def))
 import Control.DeepSeq (NFData (rnf))
-import qualified Data.List.NonEmpty as NE
 
 -- | Textual cookies. Functions assume UTF8 encoding.
 type CookiesText = [(Text, Text)]
@@ -278,10 +277,9 @@ parseSetCookie a = SetCookie
         _ -> Nothing
     }
   where
-    attributes = NE.prependList (S.split semicolon a) $ NE.singleton S8.empty
-    pairs = NE.map (parsePair . dropSpace) attributes
-    (name, value) = NE.head pairs
-    flags = map (first (S8.map toLower)) $ NE.tail pairs
+    pairs = map (parsePair . dropSpace) $ S.split semicolon a
+    (name, value) = fromMaybe mempty $ listToMaybe pairs
+    flags = map (first (S8.map toLower)) $ drop 1 pairs
     parsePair = breakDiscard equalsSign
     dropSpace = S.dropWhile (== space)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main where
 
@@ -15,7 +14,7 @@ import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
 import Data.Word (Word8)
 import Control.Arrow ((***))
-import Data.Time (UTCTime (UTCTime), toGregorian, Year)
+import Data.Time (UTCTime (UTCTime), toGregorian)
 import qualified Data.Text as T
 
 main :: IO ()
@@ -56,7 +55,7 @@ instance Show Char' where
     show (Char' w) = [toEnum $ fromEnum w]
     showList = (++) . show . concatMap show
 instance Arbitrary Char' where
-    arbitrary = fmap (Char' . toEnum) $ choose (62, 125)
+    arbitrary = Char' . toEnum <$> choose (62, 125)
 newtype SameSiteOption' = SameSiteOption' { unSameSiteOption' :: SameSiteOption }
 instance Arbitrary SameSiteOption' where
   arbitrary = fmap SameSiteOption' (elements [sameSiteLax, sameSiteStrict, sameSiteNone])
@@ -93,9 +92,8 @@ caseParseCookies = do
         expected = [("a", "a1"), ("b", "b2"), ("c", "c3")]
     map (S8.pack *** S8.pack) expected @=? parseCookies input
 
-#if !(MIN_VERSION_time(1,11,0))
+-- TODO: Use `Year` from Data.Time when we'll remove support for GHC <9.2
 type Year = Integer
-#endif
 
 -- Tests for two digit years, see:
 --


### PR DESCRIPTION
This PR proposes to replace the usage of `Data.List.NonEmtpy` with some functions from `Data.Maybe`.
The `Data.List.NonEmtpy.prependList` function is not available with GHC 8.10 and 9.0.